### PR TITLE
Change git clone from git:// to https://

### DIFF
--- a/install-retrosmc.sh
+++ b/install-retrosmc.sh
@@ -63,7 +63,7 @@ amixer set PCM 100
 # clone the retropie git and start the installation
 
             cd
-            git clone git://github.com/RetroPie/RetroPie-Setup.git
+            git clone https://github.com/RetroPie/RetroPie-Setup.git
             cd /home/osmc/RetroPie-Setup
             sudo ./retropie_setup.sh
 


### PR DESCRIPTION
git works fine for a direct connection to the internet. However problems occur when using behind a proxy/firewall. Utilizing https:// would help alleviate this problem. HTTPS uses port 443 which is very rarely blocked or restricted by firewalls/proxies.

I have just ran the script on my Pi3 behind a proxy. With the old revision I got a connection refused error from github, with https it has gone straight through.