### PR TITLE
User defined init and exit scripts

### DIFF
--- a/install-retrosmc.sh
+++ b/install-retrosmc.sh
@@ -43,6 +43,8 @@ do
 # create the config directory and file
 
             mkdir -p /home/osmc/RetroPie/scripts
+            mkdir -p /home/osmc/RetroPie/scripts/init.d
+            mkdir -p /home/osmc/RetroPie/scripts/exit.d
             touch "/home/osmc/RetroPie/scripts/retrosmc-config.cfg"
 
 # install some programs needed to run the installation and retrosmc

--- a/scripts/retropie.sh
+++ b/scripts/retropie.sh
@@ -5,6 +5,14 @@
 # emulationstation itself while stopping KODI afterwards.
 # Script by mcobit
 
+# init scripts
+if [[ -d /home/osmc/RetroPie/scripts/init.d/ ]]; then         
+        for script in /home/osmc/RetroPie/scripts/init.d/*.sh; do
+                [[ -r "$script" ]] && . "$script"        
+        done      
+        unset script                
+fi
+
 #clear the virtaul terminal 7 screen
 
 sudo openvt -c 7 -s -f clear

--- a/scripts/retropie_watchdog.sh
+++ b/scripts/retropie_watchdog.sh
@@ -42,6 +42,14 @@ while [ true ]; do
 		if [ ! "$VAR1" ]; then
 			sudo openvt -c 7 -s -f clear
 
+# exit scripts                                      
+        if [ -d /home/osmc/RetroPie/scripts/exit.d/ ]; then
+                for script in /home/osmc/RetroPie/scripts/exit.d/*.sh; do               
+                        [ -r "$script" ] && . "$script"                                 
+                done                                                                    
+                unset script                                                            
+        fi
+
 # restart kodi
 
 	sudo su -c "sudo systemctl restart mediacenter &" &


### PR DESCRIPTION
I wanted the ROMs on a network share which is mounted when I start retrosmc and unmounted when it terminates so I made these changes which execute
* init scripts in /home/osmc/RetroPie/scripts/init.d/ on start and
* exit scripts in /home/osmc/RetroPie/scripts/exit.d/ on exit.